### PR TITLE
Animate.css is missing the 'ignore' meta entry in bower.json.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,13 @@
 {
   "name": "animate.css",
   "version": "3.2.0",
-  "main": "./animate.css"
+  "main": "./animate.css",
+  "ignore": [
+    ".*",
+    "src",
+    "*.yml",
+    "Gemfile",
+    "Gemfile.lock",
+    "*.md"
+  ]
 }


### PR DESCRIPTION
Animate.css is missing the 'ignore' meta entry in bower.json (see: http://bower.io/docs/creating-packages/).  It generates a warning when installing with bower.

Bower Install Warning:
`bower invalid-meta  animate.css is missing "ignore" entry in bower.json`

I've added a simple example of the ignore entry.