### PR TITLE
Fix typo in code for animation end event listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ http://api.jquery.com/one/
 -->
 
 ```javascript
-$('#yourElement').one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', doSomething);
+$('#yourElement').on('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', doSomething);
 ```
 
 [View a video tutorial](https://www.youtube.com/watch?v=CBQGl6zokMs) on how to use Animate.css with jQuery here. 


### PR DESCRIPTION
`.on()` was mistyped as `.one()`.