### PR TITLE
Adding support for jspm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,17 @@
 {
   "name": "animate.css",
-  "version": "3.2.5",
+  "version": "3.2.5",  
   "repository": {
     "type": "git",
     "url": "https://github.com/daneden/animate.css.git"
   },
+  "jspm": {
+    "main":"animate.css!",
+    "format":"global",
+    "directories": {
+      "lib":"./"
+    }
+  },  
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-autoprefixer": "~0.4.0",


### PR DESCRIPTION
These small changes to the package.json would allow animate.css to be easily integrated into a front end application using jspm package/module loader.