### PR TITLE
package.json - version bump, add license info, fix formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,18 @@
 {
   "name": "animate.css",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/daneden/animate.css.git"
   },
+  "license": "MIT",
   "jspm": {
-    "main":"animate.css!",
-    "format":"global",
+    "main": "animate.css!",
+    "format": "global",
     "directories": {
-      "lib":"./"
+      "lib": "./"
     }
-  },  
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-autoprefixer": "~0.4.0",


### PR DESCRIPTION
- updated version field to 3.4.0,
- added license information as requested by npm –

> npm WARN package.json animate.css@3.4.0 No license field.

- added missing spaces in the jspm section