### PR TITLE
specify npm main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "animate.css",
   "version": "3.4.0",
+  "main": "animate.css",
   "repository": {
     "type": "git",
     "url": "https://github.com/daneden/animate.css.git"


### PR DESCRIPTION
for use with requiring this package via something like webpack
instead of having to do require('animate.css/animate.css')
you should be able to just do require('animate.css')