### PR TITLE
Remove unnecessary semicolon in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,4 +94,4 @@ function activateAnimations() {
   }
 
   return target;
-};
+}


### PR DESCRIPTION
Semicolons after function declarations are not necessary.
ref: http://stackoverflow.com/a/1834674