### PR TITLE
Add missing dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-concat": "^2.6.0",
-    "gulp-minify-css": "^1.2.2",
     "gulp-header": "^1.7.1",
+    "gulp-minify-css": "^1.2.2",
     "gulp-rename": "^1.2.2",
+    "gulp-util": "^3.0.7",
     "run-sequence": "^1.1.5"
   },
   "spm": {


### PR DESCRIPTION
gulp-util was missing from package.json

```
$ gulp

Error: Cannot find module 'gulp-util'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    ...
```

So added it using NPM

```
$ npm install gulp-util --save-dev
```