### PR TITLE
add postcss

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,17 +1,18 @@
 // Utilities
+var autoprefixer = require('autoprefixer');
+var cssnano = require('cssnano');
 var fs = require('fs');
 
 // Gulp
 var gulp = require('gulp');
 
 // Gulp plugins
-var gutil = require('gulp-util');
 var concat = require('gulp-concat');
+var gutil = require('gulp-util');
 var header = require('gulp-header');
-var autoprefixer = require('gulp-autoprefixer');
-var runSequence = require('run-sequence');
-var minify = require('gulp-cssnano');
+var postcss = require('gulp-postcss');
 var rename = require('gulp-rename');
+var runSequence = require('run-sequence');
 
 // Misc/global vars
 var pkg = JSON.parse(fs.readFileSync('package.json'));
@@ -54,10 +55,15 @@ gulp.task('default', function() {
 gulp.task('createCSS', function() {
   return gulp.src(activatedAnimations)
     .pipe(concat(opts.concatName))
-    .pipe(autoprefixer(opts.autoprefixer))
+    .pipe(postcss([
+      autoprefixer(opts.autoprefixer)
+    ]))
     .pipe(gulp.dest(opts.destPath))
+    .pipe(postcss([
+      autoprefixer(opts.autoprefixer),
+      cssnano({reduceIdents: {keyframes: false}})
+    ]))
     .pipe(rename(opts.minRename))
-    .pipe(minify({reduceIdents: {keyframes: false}}))
     .pipe(gulp.dest(opts.destPath));
 });
 

--- a/package.json
+++ b/package.json
@@ -20,11 +20,12 @@
     }
   },
   "devDependencies": {
+    "autoprefixer": "^6.3.2",
+    "cssnano": "^3.5.1",
     "gulp": "^3.9.0",
-    "gulp-autoprefixer": "^3.1.0",
     "gulp-concat": "^2.6.0",
-    "gulp-cssnano": "^2.0.0",
     "gulp-header": "^1.7.1",
+    "gulp-postcss": "^6.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-util": "^3.0.7",
     "run-sequence": "^1.1.5"


### PR DESCRIPTION
Use [postcss](https://github.com/postcss/postcss) to transform css with [autoprefixer](https://github.com/postcss/autoprefixer) and [cssnano](https://github.com/ben-eb/cssnano).
Both are now built on top of postcss. They will always be more up to date than any gulp-plugin middleware.