### PR TITLE
[bower.json] source dir removed from the ignore array

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "main": "./animate.css",
   "ignore": [
     ".*",
-    "source",
     "*.yml",
     "Gemfile",
     "Gemfile.lock",


### PR DESCRIPTION
If we install animate.css via bower and we want to compile the library using gulp, the source folder should  exists. See issue #509