### PR TITLE
Replace unnecessary jQuery $(this) to this

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ $.fn.extend({
     animateCss: function (animationName) {
         var animationEnd = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';
         this.addClass('animated ' + animationName).one(animationEnd, function() {
-            this.removeClass('animated ' + animationName);
+            $(this).removeClass('animated ' + animationName);
         });
     }
 });

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ You can also extend jQuery to add a function that does it all for you:
 $.fn.extend({
     animateCss: function (animationName) {
         var animationEnd = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';
-        $(this).addClass('animated ' + animationName).one(animationEnd, function() {
-            $(this).removeClass('animated ' + animationName);
+        this.addClass('animated ' + animationName).one(animationEnd, function() {
+            this.removeClass('animated ' + animationName);
         });
     }
 });


### PR DESCRIPTION
**Fixing the jQuery plugin example:**

When behaving as a jQuery plugin, `this` automatically points to `$(this)`. Using `$(this)` again inside a jQuery plugin may have some performance hits as it will recreate a jQuery self object.