### PR TITLE
Fixed broken CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ $ bower install animate.css --save
     <link rel="stylesheet" href="animate.min.css">
   </head>
   ```
-  or use the version hosted by [SmallCDN](http://smallcdn.rocks)
+  or use the version hosted by [cdnjs](https://cdnjs.com/libraries/animate.css)
   ```html
   <head>
-    <link rel="stylesheet" href="http://s.mlcdn.co/animate.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css">
   </head>
   ```
 2. Add the class `animated` to the element you want to animate.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ bower install animate.css --save
     <link rel="stylesheet" href="animate.min.css">
   </head>
   ```
-  or use the version hosted by [cdnjs](https://cdnjs.com/libraries/animate.css)
+  or use the version hosted by [CDNJS](https://cdnjs.com/libraries/animate.css)
   ```html
   <head>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css">
@@ -121,10 +121,10 @@ To use animate.css in your website, simply drop the stylesheet into your documen
   <link rel="stylesheet" href="animate.min.css">
 </head>
 ```
-or use the version hosted by [SmallCDN](http://smallcdn.rocks)
+or use the version hosted by [CDNJS](https://cdnjs.com/libraries/animate.css)
 ```html
 <head>
-  <link rel="stylesheet" href="http://s.mlcdn.co/animate.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css">
 </head>
 ```
 


### PR DESCRIPTION
Looks like Small CDN is down.  I updated the cdn to use cdnjs which appears to be working. We are actually using your library in our class so thank you for creating it!