### PR TITLE
explain primitive chaining of animations (in README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,19 +159,28 @@ You can also extend jQuery to add a function that does it all for you:
 
 ```javascript
 $.fn.extend({
-    animateCss: function (animationName) {
+    animateCss: function (animationName, onFinish) {
         var animationEnd = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';
         this.addClass('animated ' + animationName).one(animationEnd, function() {
             $(this).removeClass('animated ' + animationName);
+            if (typeof onFinish === 'function') onFinish.call(this);
         });
     }
 });
 ```
 
-And use it like this:
+And use that function to trigger animations like this:
 
 ```javascript
 $('#yourElement').animateCss('bounce');
+```
+
+You may also use it to make animation chains like this:
+
+```javascript
+$('#yourElement').animateCss('bounce', function() {
+    $(this).animateCss('shake');
+});
 ```
 
 You can change the duration of your animations, add a delay or change the number of times that it plays:


### PR DESCRIPTION
This patch adds a second argument to the jQuery-based method `animateCss` (proposed in README) to facilitate animation chaining (or, potentially, to trigger any other useful behaviour such as `$(this).hide()` or `$(this).remove()`) after the animation's end.

This approach is not elegant (as mentioned in #658 by @Legends) but it still saves time if it's explained in README.