### PR TITLE
Add animation chaining to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,16 +159,19 @@ You can also extend jQuery to add a function that does it all for you:
 
 ```javascript
 $.fn.extend({
-  animateCss: function (animationNames, index) {
+  animateCss: function (animationNames, callback) {
     var animationEnd = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';
     if (!Array.isArray(animationNames)) {
       animationNames = [animationNames];
     }
     this.addClass('animated');
-    animationNames.forEach(function(e) {
+    animationNames.forEach(function (e, index, array) {
       this.queue(function (next) {
         $(this).addClass(e).one(animationEnd, function () {
           $(this).removeClass(e);
+          if (typeof(callback) === 'function' && index === array.length - 1) {
+            callback();
+          }
           next();
         });
       });
@@ -199,6 +202,16 @@ And you can chain with other jQuery methods as well:
 
 ```javascript
 $('#yourElement').animateCss('flipOutX').animateCss('flipInX').delay(1000).fadeOut();
+```
+
+You can also pass in a callback that will execute once your animation(s) complete. 
+This can be useful if you want to sequence methods that don't use the jQuery effects 
+queue without resorting to something like `setTimeout`.
+
+```javascript
+//flip element out of view, then change it's html, then flip it back into view
+var myElement = $('#yourElement');
+myElement.animateCss('flipOutX', function(){ myElement.html('New html'); }).animateCss('flipInX');
 ```
 
 You can change the duration of your animations, add a delay or change the number of times that it plays:

--- a/README.md
+++ b/README.md
@@ -160,20 +160,20 @@ You can also extend jQuery to add a function that does it all for you:
 ```javascript
 $.fn.extend({
   animateCss: function (animationNames, index) {
-    if (!Array.isArray(animationNames)){
+    var animationEnd = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';
+    if (!Array.isArray(animationNames)) {
       animationNames = [animationNames];
     }
-    if (typeof(index)==='undefined') { index = 0; }
-    var animationEnd = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';   
-    this.addClass('animated ' + animationNames[index]).one(animationEnd, index, function () {
-      $(this).removeClass(animationNames[index]);
-      if (index < animationNames.length - 1) {
-        $(this).animateCss(animationNames, index + 1);
-      }else{
-        $(this).removeClass('animated');
-        return this;
-      }
-    });
+    this.addClass('animated');
+    animationNames.forEach(function(e) {
+      this.queue(function (next) {
+        $(this).addClass(e).one(animationEnd, function () {
+          $(this).removeClass(e);
+          next();
+        });
+      });
+    }, this);
+    return this;
   }
 });
 ```
@@ -188,6 +188,17 @@ Or like this to chain multiple animations:
 
 ```javascript
 $('#yourElement').animateCss(['flipOutX', 'flipInX']);
+```
+or
+
+```javascript
+$('#yourElement').animateCss('flipOutX').animateCss('flipInX');
+```
+
+And you can chain with other jQuery methods as well:
+
+```javascript
+$('#yourElement').animateCss('flipOutX').animateCss('flipInX').delay(1000).fadeOut();
 ```
 
 You can change the duration of your animations, add a delay or change the number of times that it plays:

--- a/README.md
+++ b/README.md
@@ -159,12 +159,22 @@ You can also extend jQuery to add a function that does it all for you:
 
 ```javascript
 $.fn.extend({
-    animateCss: function (animationName) {
-        var animationEnd = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';
-        this.addClass('animated ' + animationName).one(animationEnd, function() {
-            $(this).removeClass('animated ' + animationName);
-        });
+  animateCss: function (animationNames, index) {
+    if (!Array.isArray(animationNames)){
+      animationNames = [animationNames];
     }
+    if (typeof(index)==='undefined') { index = 0; }
+    var animationEnd = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';   
+    this.addClass('animated ' + animationNames[index]).one(animationEnd, index, function () {
+      $(this).removeClass(animationNames[index]);
+      if (index < animationNames.length - 1) {
+        $(this).animateCss(animationNames, index + 1);
+      }else{
+        $(this).removeClass('animated');
+        return this;
+      }
+    });
+  }
 });
 ```
 
@@ -172,6 +182,12 @@ And use it like this:
 
 ```javascript
 $('#yourElement').animateCss('bounce');
+```
+
+Or like this to chain multiple animations:
+
+```javascript
+$('#yourElement').animateCss(['flipOutX', 'flipInX']);
 ```
 
 You can change the duration of your animations, add a delay or change the number of times that it plays:


### PR DESCRIPTION
This patch enables chaining animations by taking an array of animation names as an argument, e.g.  `$('#yourElement').animateCss(['flipOutX', 'flipInX']);` 

It also preserves the existing behavior for a single animation name passed in as a string, e.g. `$('#yourElement').animateCss('bounce');` 

Also, makes chainable and utilizes jQuery effects queue:

`$('#yourElement').animateCss('bounce').delay(500).animateCss('flip').fadeOut()`

And, you can pass in a callback  to sequence methods that don't use the jQuery effects 
queue without resorting to something like `setTimeout`:

```javascript
//flip element out of view, then change it's html, then flip it back into view
var myElement = $('#yourElement');
myElement.animateCss('flipOutX', function(){ myElement.html('New html'); }).animateCss('flipInX');
```

Addresses #658 and #671 