### PR TITLE
Fixed Custom Builds 

### DIFF
--- a/animate-config.json
+++ b/animate-config.json
@@ -1,121 +1,121 @@
 {
 
-  "attention_seekers": [
-    "bounce",
-    "flash",
-    "pulse",
-    "rubberBand",
-    "shake",
-    "headShake",
-    "swing",
-    "tada",
-    "wobble",
-    "jello"
-  ],
+  "attention_seekers": {
+    "bounce": true,
+    "flash": true,
+    "pulse": true,
+    "rubberBand": true,
+    "shake": true,
+    "headShake": true,
+    "swing": true,
+    "tada": true,
+    "wobble": true,
+    "jello": true
+  },
 
-  "bouncing_entrances": [
-    "bounceIn",
-    "bounceInDown",
-    "bounceInLeft",
-    "bounceInRight",
-    "bounceInUp"
-  ],
+  "bouncing_entrances": {
+    "bounceIn": true,
+    "bounceInDown": true,
+    "bounceInLeft": true,
+    "bounceInRight": true,
+    "bounceInUp": true
+  },
 
-  "bouncing_exits": [
-    "bounceOut",
-    "bounceOutDown",
-    "bounceOutLeft",
-    "bounceOutRight",
-    "bounceOutUp"
-  ],
+  "bouncing_exits": {
+    "bounceOut": true,
+    "bounceOutDown": true,
+    "bounceOutLeft": true,
+    "bounceOutRight": true,
+    "bounceOutUp": true
+  },
 
-  "fading_entrances": [
-    "fadeIn",
-    "fadeInDown",
-    "fadeInDownBig",
-    "fadeInLeft",
-    "fadeInLeftBig",
-    "fadeInRight",
-    "fadeInRightBig",
-    "fadeInUp",
-    "fadeInUpBig"
-  ],
+  "fading_entrances": {
+    "fadeIn": true,
+    "fadeInDown": true,
+    "fadeInDownBig": true,
+    "fadeInLeft": true,
+    "fadeInLeftBig": true,
+    "fadeInRight": true,
+    "fadeInRightBig": true,
+    "fadeInUp": true,
+    "fadeInUpBig": true
+  },
 
-  "fading_exits": [
-    "fadeOut",
-    "fadeOutDown",
-    "fadeOutDownBig",
-    "fadeOutLeft",
-    "fadeOutLeftBig",
-    "fadeOutRight",
-    "fadeOutRightBig",
-    "fadeOutUp",
-    "fadeOutUpBig"
-  ],
+  "fading_exits": {
+    "fadeOut": true,
+    "fadeOutDown": true,
+    "fadeOutDownBig": true,
+    "fadeOutLeft": true,
+    "fadeOutLeftBig": true,
+    "fadeOutRight": true,
+    "fadeOutRightBig": true,
+    "fadeOutUp": true,
+    "fadeOutUpBig": true
+  },
 
-  "flippers": [
-    "flip",
-    "flipInX",
-    "flipInY",
-    "flipOutX",
-    "flipOutY"
-  ],
+  "flippers": {
+    "flip": true,
+    "flipInX": true,
+    "flipInY": true,
+    "flipOutX": true,
+    "flipOutY": true
+  },
 
-  "lightspeed": [
-    "lightSpeedIn",
-    "lightSpeedOut"
-  ],
+  "lightspeed": {
+    "lightSpeedIn": true,
+    "lightSpeedOut": true
+  },
 
-  "rotating_entrances": [
-    "rotateIn",
-    "rotateInDownLeft",
-    "rotateInDownRight",
-    "rotateInUpLeft",
-    "rotateInUpRight"
-  ],
+  "rotating_entrances": {
+    "rotateIn": true,
+    "rotateInDownLeft": true,
+    "rotateInDownRight": true,
+    "rotateInUpLeft": true,
+    "rotateInUpRight": true
+  },
 
-  "rotating_exits": [
-    "rotateOut",
-    "rotateOutDownLeft",
-    "rotateOutDownRight",
-    "rotateOutUpLeft",
-    "rotateOutUpRight"
-  ],
+  "rotating_exits": {
+    "rotateOut": true,
+    "rotateOutDownLeft": true,
+    "rotateOutDownRight": true,
+    "rotateOutUpLeft": true,
+    "rotateOutUpRight": true
+  },
 
-  "specials": [
-    "hinge",
-    "jackInTheBox",
-    "rollIn",
-    "rollOut"
-  ],
+  "specials": {
+    "hinge": true,
+    "jackInTheBox": true,
+    "rollIn": true,
+    "rollOut": true
+  },
 
-  "zooming_entrances": [
-    "zoomIn",
-    "zoomInDown",
-    "zoomInLeft",
-    "zoomInRight",
-    "zoomInUp"
-  ],
+  "zooming_entrances": {
+    "zoomIn": true,
+    "zoomInDown": true,
+    "zoomInLeft": true,
+    "zoomInRight": true,
+    "zoomInUp": true
+  },
 
-  "zooming_exits": [
-    "zoomOut",
-    "zoomOutDown",
-    "zoomOutLeft",
-    "zoomOutRight",
-    "zoomOutUp"
-  ],
+  "zooming_exits": {
+    "zoomOut": true,
+    "zoomOutDown": true,
+    "zoomOutLeft": true,
+    "zoomOutRight": true,
+    "zoomOutUp": true
+  },
 
-  "sliding_entrances": [
-    "slideInDown",
-    "slideInLeft",
-    "slideInRight",
-    "slideInUp"
-  ],
+  "sliding_entrances": {
+    "slideInDown": true,
+    "slideInLeft": true,
+    "slideInRight": true,
+    "slideInUp": true
+  },
 
-  "sliding_exits": [
-    "slideOutDown",
-    "slideOutLeft",
-    "slideOutRight",
-    "slideOutUp"
-  ]
+  "sliding_exits": {
+    "slideOutDown": true,
+    "slideOutLeft": true,
+    "slideOutRight": true,
+    "slideOutUp": true
+  }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,8 +88,7 @@ function activateAnimations() {
       files = categories[category];
 
       for (file in files) {
-        var isActive = files[file];
-        if (isActive) {
+        if (files[file]) { // marked as true
           target.push('source/' + category + '/' + file + '.css');
           count += 1;
         }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,9 +87,12 @@ function activateAnimations() {
     if (categories.hasOwnProperty(category)) {
       files = categories[category];
 
-      for (var i = 0; i < files.length; ++i) {
-        target.push('source/' + category + '/' + files[i] + '.css');
-        count += 1;
+      for (file in files) {
+        var isActive = files[file];
+        if (isActive) {
+          target.push('source/' + category + '/' + file + '.css');
+          count += 1;
+        }
       }
     }
   }


### PR DESCRIPTION
First of all congratulations for this simple and easy to use CSS library ㊗️ 

The documentation spoke about custom builds to reduce size and showed a way to customize them:

`"attention_seekers": {
  "bounce": true,
  "flash": false,
  "pulse": false,
  "shake": true,
  "headShake": true,
  "swing": true,
  "tada": true,
  "wobble": true,
  "jello":true
}`

However that never worked for me if I wanted to add only one animation, the whole group of animations was always gone independently of the boolean value, that's how I found out it was a bug.

I corrected the gulpfile to iterate objects instead of the for loop for arrays, and corrected animate-config.json to fit the way is expected to work by the documentation.

With the current fix I am finally able to use just the "shake" animation with only 624B instead of the 17Kb of the original file 😄 