### PR TITLE
Update the devDependencies, Fix build failing status, and some minor changes!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 .DS_Store
 test/
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+- "9"
+- "8"
 - "6"
-- "6.1"
-- "5.11"
 before_script:
   - npm install -g gulp
 script: gulp

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,7 @@ var opts = {
   concatName: 'animate.css',
 
   autoprefixer: {
-    browsers: ['> 1%, last 2 versions, Firefox ESR'],
+    browsers: ['> 1%', 'last 2 versions', 'Firefox ESR'],
     cascade: false
   },
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "autoprefixer": "^7.1.6",
     "cssnano": "^3.5.1",
-    "gulp": "^3.9.0",
+    "gulp": "^3.9.1",
     "gulp-concat": "^2.6.0",
     "gulp-header": "^1.7.1",
     "gulp-postcss": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -20,15 +20,15 @@
     }
   },
   "devDependencies": {
-    "autoprefixer": "^6.3.2",
+    "autoprefixer": "^7.1.6",
     "cssnano": "^3.5.1",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
     "gulp-header": "^1.7.1",
-    "gulp-postcss": "^6.1.0",
+    "gulp-postcss": "^7.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-util": "^3.0.7",
-    "run-sequence": "^1.1.5"
+    "run-sequence": "^2.2.0"
   },
   "spm": {
     "main": "./animate.css"


### PR DESCRIPTION
I saw that autoprefixer, gulp-postcss, and run-sequencer are out of date. I update it and it should be using all the most updated devDependencies. I notice also that the build in travis CI is failing so I fix the issue. I found out that the issue is in the syntax in autoprefixer. I made some minor changes such as updating the gulp version and adding npm-debug.log in the gitignore file.