### PR TITLE
Add a Gulp task to build SCSS version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,6 +42,8 @@ var opts = {
     ' * Copyright (c) <%= new Date().getFullYear() %> <%= author.name %>',
     ' */\n\n',
   ].join('\n'),
+
+  scssDestPath: './SCSS',
 };
 
 // ----------------------------
@@ -68,6 +70,20 @@ gulp.task('addHeader', function() {
     .src('*.css')
     .pipe(header(opts.banner, pkg))
     .pipe(gulp.dest(opts.destPath));
+});
+
+gulp.task('createSCSS', function() {
+  return gulp
+    .src('source/**/**.css')
+    .pipe(
+      rename(function(path) {
+        path.extname = '.scss';
+        if (path.basename !== '_base') {
+          path.basename = '_' + path.basename;
+        }
+      }),
+    )
+    .pipe(gulp.dest(opts.scssDestPath));
 });
 
 // ----------------------------


### PR DESCRIPTION
In the most cases, I think SCSS users only want to import the actual SCSS files they needed (in favor to reduce the CSS file size). 

I added a task to copy the source to SCSS dir and rename them into Sass partials.

You can use it as:
```
@import "base";
@import "bouncing_entrances/bounceInLeft";
```

In another side, it would be great to rename the `source` dir directly and compile a CSS version from it.