### PR TITLE
Remove `sudo npm` from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ Animate.css is powered by [gulp.js](http://gulpjs.com/), which means you can cre
 
 ```sh
 $ cd path/to/animate.css/
-$ sudo npm install
+$ npm install
 ```
 
-Next, run `gulp` to compile your custom builds. For example, if you want only some of the “attention seekers”, simply edit the `animate-config.json` file to select only the animations you want to use.
+Next, run `npx gulp` to compile your custom builds. For example, if you want only some of the “attention seekers”, simply edit the `animate-config.json` file to select only the animations you want to use.
 
 ```javascript
 "attention_seekers": {


### PR DESCRIPTION
Running `npm` as root has a lot of disadvantages (ref: https://medium.com/@ExplosionPills/dont-use-sudo-with-npm-still-66e609f5f92). Modern versions of npm allow running tools from `node_modules/.bin` by calling `npx`.