### PR TITLE
Move browserlist autoprefixer config to package.json

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,6 @@ var opts = {
   concatName: 'animate.css',
 
   autoprefixer: {
-    browsers: ['> 1%', 'last 2 versions', 'Firefox ESR'],
     cascade: false,
   },
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
       "lib": "./"
     }
   },
+  "browserslist": [
+    "> 1%",
+    "last 2 versions",
+    "Firefox ESR"
+  ],
   "devDependencies": {
     "autoprefixer": "^9.0.1",
     "cssnano": "^4.0.3",


### PR DESCRIPTION
Hi, love this repo so much
and I want to start adding animation
but, when I ran gulp there were browserlist warnings

i move the browserlist in autoprefixer to package.json 
based on their best practice readme

Cheers