### PR TITLE
Add contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing to Animate.css
+Thanks for your interest in contributing to Animate.css! Before contributing, please make sure you understand the guidelines provided here. Animate.css is widely used, so it’s important to maintain a high level of quality and to contribute with the interests of the community in mind.
+
+## Design Guidelines
+Animations, like many facets of visual and interaction design, can be highly subjective. Maintaining a consistent library of animations in an active community can be difficult; these design guidelines are designed to help encourage thoughtful criticism of new animations that are proposed for Animate.css.
+
+The animations in Animate.css should follow a few key principles:
+
+- **Animations should be subtle.** Avoid creating animations that involve large translations, or span a natural duration of longer than 1 second.
+- **Animations should be tolerable.** Related to subtlety, animations should be tolerable—seeing them repeatedly should not become too annoying or overbearing.
+- **Animations should not interfere with document flow or control/input availability.** In other words, the absence of an animation should never reduce usability of a product: they should be non-critical and seen as “progressive enhancements”. Avoid animations that change properties such as `position` or `display`.
+- **Animations should be helpful.** They should be designed to guide users to a point of interest, ease natural reading order, or to communicate relationships between elements.
+- **Animations should feel familial.** Avoid introducing animations that feel out-of-place compared to the existing set.
+- **Animations should feel natural.** Animations should reflect, as much as is reasonable, motion that occurs in natural physics. Avoid extreme timing functions, and model animations on real-world events.


### PR DESCRIPTION
In order to guide contributors to better outcomes, I wanted to add contribution guidelines that highlight some of the reasons new animations are rejected.

@eltonmesquita @WarenGonzaga, I’m open to any suggestions on what else to add to these guidelines.

- [x] Add contribution section currently in Readme
- [x] Add guidance around third-party libraries and dev tools